### PR TITLE
Add necessary exts to shared_preload_libs and extwlist in PG18

### DIFF
--- a/scripts/spilo_commons.py
+++ b/scripts/spilo_commons.py
@@ -12,9 +12,9 @@ LIB_DIR = '/usr/lib/postgresql'
 
 # (min_version, max_version, shared_preload_libraries, extwlist.extensions)
 extensions = {
-    'timescaledb':    (13, 17, False,  True),
-    'pg_partman':     (13, 17, False, True),
-    'pg_stat_statements':   (13, 17, True, True)
+    'timescaledb':    (13, 18, False,  True),
+    'pg_partman':     (13, 18, False, True),
+    'pg_stat_statements':   (13, 18, True, True)
 }
 
 def adjust_extensions(old, version, extwlist=False):


### PR DESCRIPTION
Required extensions are not added to shared_reload_libraries and extwlist.extensions in PG18